### PR TITLE
feat: 添加输入时页面拉起功能

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dada-element/components",
-  "version": "1.2.20",
+  "version": "1.2.21",
 
   "description": "all components are settled here",
   "author": "gjssss",

--- a/packages/components/src/components/Input/Input.vue
+++ b/packages/components/src/components/Input/Input.vue
@@ -181,7 +181,9 @@ function focus() {
 }
 
 function focusHandle(e: InputOnFocusEvent) {
-  keyboardHeight.value = `${e.detail.height}px`
+  if (!props.keyboard)
+    keyboardHeight.value = `${e.detail.height}px`
+
   emits('onFocus', e)
 }
 

--- a/packages/components/src/components/Input/Input.vue
+++ b/packages/components/src/components/Input/Input.vue
@@ -71,6 +71,11 @@ const props = withDefaults(defineProps<{
    * 是否为块状元素
    */
   block?: boolean
+
+  /**
+   * 键盘弹起时，是否自动上推页面
+   */
+  keyboard: boolean
 }>(), {
   placeholder: '',
   shadow: false,
@@ -80,6 +85,7 @@ const props = withDefaults(defineProps<{
   maxlength: 140,
   type: 'default',
   block: false,
+  keyboard: false,
 })
 
 const emits = defineEmits<{
@@ -155,6 +161,7 @@ function inputHandle(e: InputOnInputEvent) {
 }
 
 function blurHandle(e: InputOnBlurEvent) {
+  keyboardHeight.value = 0
   isFocus.value = false
   emits('onBlur', e)
 
@@ -174,7 +181,7 @@ function focus() {
 }
 
 function focusHandle(e: InputOnFocusEvent) {
-  keyboardHeight.value = e.detail.height
+  keyboardHeight.value = `${e.detail.height}px`
   emits('onFocus', e)
 }
 
@@ -192,9 +199,11 @@ defineExpose({
       <div class="__dd-input-slot prefix">
         <slot name="prefix" />
       </div>
-      <input class="__dd-input" :class="classAry" :placeholder="placeholder" placeholder-class="__dd-input-placeholder"
+      <input
+        class="__dd-input" :class="classAry" :placeholder="placeholder" placeholder-class="__dd-input-placeholder"
         :value="value" :focus="isFocus" :password="props.password" :maxlength="props.maxlength" :disabled="props.disabled"
-        @input="inputHandle" @blur="blurHandle" @focus="focusHandle">
+        :adjust-position="props.keyboard" @input="inputHandle" @blur="blurHandle" @focus="focusHandle"
+      >
       <div class="__dd-input-slot suffix">
         <slot name="suffix" />
       </div>

--- a/packages/components/src/components/Input/demo/inputBase.vue
+++ b/packages/components/src/components/Input/demo/inputBase.vue
@@ -17,10 +17,10 @@ function focusTest() {
 <template>
   <div>
     <div class="mt ml">
-      <DadaInput type="primary" border placeholder="测试一下onFocus" @on-focus="focusTest" />
+      <DadaInput type="primary" border placeholder="测试一下onFocus" :keyboard="true" @on-focus="focusTest" />
     </div>
     <div class="mt ml">
-      <DadaInput shadow placeholder="不带shadow" />
+      <DadaInput shadow placeholder="不带shadow" :keyboard="true" />
     </div>
     <div class="mt ml">
       <DadaInput type="primary" border placeholder="带border" />


### PR DESCRIPTION
1. 给input添加keyboard属性，用于输入文本时选择是否拉起页面